### PR TITLE
refactor : Jpa N+1 문제 해결을 위해 image, hashtag 분리하여 dto에 담음

### DIFF
--- a/src/main/java/org/baratie/yumyum/domain/hashtag/repository/HashtagCustomRepository.java
+++ b/src/main/java/org/baratie/yumyum/domain/hashtag/repository/HashtagCustomRepository.java
@@ -1,0 +1,12 @@
+package org.baratie.yumyum.domain.hashtag.repository;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public interface HashtagCustomRepository {
+
+    Map<Long, List<String>> findHashtagByStoreId();
+}

--- a/src/main/java/org/baratie/yumyum/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/org/baratie/yumyum/domain/hashtag/repository/HashtagRepository.java
@@ -1,15 +1,13 @@
 package org.baratie.yumyum.domain.hashtag.repository;
 
-import org.baratie.yumyum.domain.category.domain.Category;
 import org.baratie.yumyum.domain.hashtag.domain.Hashtag;
-import org.baratie.yumyum.domain.hashtag.dto.HashtagDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagCustomRepository {
 
     List<Hashtag> findByStoreId(Long storeId);
 }

--- a/src/main/java/org/baratie/yumyum/domain/hashtag/repository/Impl/HashtagCustomRepositoryImpl.java
+++ b/src/main/java/org/baratie/yumyum/domain/hashtag/repository/Impl/HashtagCustomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package org.baratie.yumyum.domain.hashtag.repository.Impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.baratie.yumyum.domain.hashtag.repository.HashtagCustomRepository;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static org.baratie.yumyum.domain.hashtag.domain.QHashtag.*;
+import static org.baratie.yumyum.domain.store.domain.QStore.*;
+
+@RequiredArgsConstructor
+public class HashtagCustomRepositoryImpl implements HashtagCustomRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Map<Long, List<String>> findHashtagByStoreId() {
+        return query.select(hashtag.id, hashtag.content)
+                .from(hashtag)
+                .leftJoin(hashtag.store, store)
+                .transform(groupBy(store.id).as(list(hashtag.content)));
+    }
+}

--- a/src/main/java/org/baratie/yumyum/domain/review/repository/ReviewCustomRepository.java
+++ b/src/main/java/org/baratie/yumyum/domain/review/repository/ReviewCustomRepository.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @Repository
 public interface ReviewCustomRepository {
 
-    Slice<ReviewAllDto> findAllReviews(Pageable pageable);
+    Slice<ReviewAllDto> findAllReviews(Map<Long, List<String>> imageList, Pageable pageable);
 
     Slice<StoreReviewDto> findReviewByStoreId(Long storeId, Map<Long, List<String>> imageList, Pageable pageable);
 

--- a/src/main/java/org/baratie/yumyum/domain/review/repository/impl/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/org/baratie/yumyum/domain/review/repository/impl/ReviewCustomRepositoryImpl.java
@@ -64,7 +64,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
      * @return 최신 작성순으로 리뷰 전체 리스트 리턴
      */
     @Override
-    public Slice<ReviewAllDto> findAllReviews(Pageable pageable) {
+    public Slice<ReviewAllDto> findAllReviews(Map<Long, List<String>> imageList, Pageable pageable) {
 
         List<ReviewAllDto> results = query
                 .select(Projections.constructor(ReviewAllDto.class,
@@ -86,14 +86,12 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        for(ReviewAllDto dto : results){
-            List<String> images = query.select(
-                            image.imageUrl)
-                    .from(image)
-                    .where(image.review.id.eq(dto.getReviewId()))
-                    .fetch();
-            dto.addImageList(images);
-        }
+        results.forEach(dto -> {
+            List<String> images = imageList.get(dto.getReviewId());
+            if (images != null) {
+                dto.addImageList(images);
+            }
+        });
 
         boolean hasNext = results.size() > pageable.getPageSize();
 

--- a/src/main/java/org/baratie/yumyum/domain/review/service/ReviewReadService.java
+++ b/src/main/java/org/baratie/yumyum/domain/review/service/ReviewReadService.java
@@ -32,7 +32,8 @@ public class ReviewReadService {
      * @return
      */
     public CustomSliceDto getAllReview(Pageable pageable){
-        Slice<ReviewAllDto> allReviews = reviewRepository.findAllReviews(pageable);
+        Map<Long, List<String>> imageList = imageRepository.findImageByReviewIdList();
+        Slice<ReviewAllDto> allReviews = reviewRepository.findAllReviews(imageList ,pageable);
 
         return new CustomSliceDto(allReviews);
     }

--- a/src/main/java/org/baratie/yumyum/domain/store/repository/SearchCustomRepository.java
+++ b/src/main/java/org/baratie/yumyum/domain/store/repository/SearchCustomRepository.java
@@ -4,10 +4,11 @@ import org.baratie.yumyum.domain.store.dto.SearchStoreDto;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 @Repository
 public interface SearchCustomRepository {
-    List<SearchStoreDto> findSearchStore(Long memberId, String keyword);
+    List<SearchStoreDto> findSearchStore(Long memberId, Map<Long, List<String>> imageList, Map<Long, List<String>> hashtagList, String keyword);
 
-    List<SearchStoreDto> findNearByStore(Double lng, Double lat);
+    List<SearchStoreDto> findNearByStore(Double lng, Double lat, Map<Long, List<String>> imageList, Map<Long, List<String>> hashtagList);
 }

--- a/src/main/java/org/baratie/yumyum/domain/store/service/SearchService.java
+++ b/src/main/java/org/baratie/yumyum/domain/store/service/SearchService.java
@@ -1,12 +1,15 @@
 package org.baratie.yumyum.domain.store.service;
 
 import lombok.RequiredArgsConstructor;
+import org.baratie.yumyum.domain.hashtag.repository.HashtagRepository;
 import org.baratie.yumyum.domain.store.dto.SearchStoreDto;
 import org.baratie.yumyum.domain.store.repository.StoreRepository;
+import org.baratie.yumyum.global.utils.file.repository.ImageRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +17,8 @@ import java.util.List;
 public class SearchService {
 
     private final StoreRepository storeRepository;
+    private final ImageRepository imageRepository;
+    private final HashtagRepository hashtagRepository;
 
     /**
      * 검색 시 맛집 리스트 조회
@@ -22,7 +27,9 @@ public class SearchService {
      * @return 검색 조건에 맞는 맛집 리스트 30개 제한으로 리턴
      */
     public List<SearchStoreDto> getSearchStores(Long memberId, String keyword) {
-        return storeRepository.findSearchStore(memberId, keyword);
+        Map<Long, List<String>> imageList = imageRepository.findImageByStoreIdList();
+        Map<Long, List<String>> hashtagList = hashtagRepository.findHashtagByStoreId();
+        return storeRepository.findSearchStore(memberId, imageList, hashtagList, keyword);
     }
 
     /**
@@ -32,6 +39,8 @@ public class SearchService {
      * @return 전달받은 위치 반경 1km 내의 맛집 리스트 리턴
      */
     public List<SearchStoreDto> getNearByStore(Double lng, Double lat) {
-        return storeRepository.findNearByStore(lng, lat);
+        Map<Long, List<String>> imageList = imageRepository.findImageByStoreIdList();
+        Map<Long, List<String>> hashtagList = hashtagRepository.findHashtagByStoreId();
+        return storeRepository.findNearByStore(lng, lat, imageList, hashtagList);
     }
 }

--- a/src/main/java/org/baratie/yumyum/global/utils/file/repository/ImageCustomRepository.java
+++ b/src/main/java/org/baratie/yumyum/global/utils/file/repository/ImageCustomRepository.java
@@ -10,4 +10,5 @@ public interface ImageCustomRepository {
 
     Map<Long, List<String>> findImageByReviewIdList();
 
+    Map<Long, List<String>> findImageByStoreIdList();
 }

--- a/src/main/java/org/baratie/yumyum/global/utils/file/repository/impl/ImageCustomRepositoryImpl.java
+++ b/src/main/java/org/baratie/yumyum/global/utils/file/repository/impl/ImageCustomRepositoryImpl.java
@@ -11,6 +11,7 @@ import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 import static org.baratie.yumyum.domain.review.domain.QReview.*;
 import static org.baratie.yumyum.global.utils.file.domain.QImage.*;
+import static org.baratie.yumyum.domain.store.domain.QStore.*;
 
 @RequiredArgsConstructor
 public class ImageCustomRepositoryImpl implements ImageCustomRepository {
@@ -25,6 +26,15 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
                 .from(image)
                 .leftJoin(image.review, review)
                 .transform(groupBy(review.id).as(list(image.imageUrl)));
+    }
+
+    @Override
+    public Map<Long, List<String>> findImageByStoreIdList() {
+
+        return query.select(image.store.id, image.imageUrl)
+                .from(image)
+                .leftJoin(image.store, store)
+                .transform(groupBy(store.id).as(list(image.imageUrl)));
     }
 
 }


### PR DESCRIPTION
리뷰 전체 조회 시 이미지 삽입을 분리하여 Jpa n+1 문제 해결

맛집 리스트 및 검색 조회 시 이미지, 해시태그 삽입을 분리하여 Jpa N+1 문제 해결

querydsl에서는 transform을 통해 groupBy를 통해 id로 묶은 다음 해당 id에 list로 이미지, 해시태그 담아줌